### PR TITLE
Use GNU-Make 4.3+ compatible space variable 'hack'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ VERSION = $(shell python version.py $(CONFIG))
 .ONESHELL:
 .PHONY: all
 
-space :=
-space +=
+space := $() $()
 
 all: Qahiri-Regular.otf Qahiri-Regular.ttx
 


### PR DESCRIPTION
The hack that has been around for years (and I have used myself many places, possibly even introducing you to it :fearful:) to create a variable with a single space relied on GNU-Make's handling of appending variables always adding a space first. In version 4.3 they introduced a breaking change which effectively trims after append operations.

> * WARNING: Backward-incompatibility!
  Previously appending using '+=' to an empty variable would result in a value
  starting with a space.  Now the initial space is only added if the variable
  already contains some value.  Similarly, appending an empty string does not
  add a trailing space. ([source](https://git.savannah.gnu.org/cgit/make.git/tree/NEWS))

This PR uses a current and backwards compatible way of avoiding the trim operation.